### PR TITLE
proc: remove SafetyNet checks from /proc/cmdline.c

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char new_command_line[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", new_command_line);
 	return 0;
 }
 
@@ -21,9 +24,39 @@ static const struct file_operations cmdline_proc_fops = {
 	.release	= single_release,
 };
 
+static void remove_flag(char *cmd, const char *flag)
+{
+	char *start_addr, *end_addr;
+
+	/* Ensure all instances of a flag are removed */
+	while ((start_addr = strstr(cmd, flag))) {
+		end_addr = strchr(start_addr, ' ');
+		if (end_addr)
+			memmove(start_addr, end_addr + 1, strlen(end_addr));
+		else
+			*(start_addr - 1) = '\0';
+	}
+}
+
+static void remove_safetynet_flags(char *cmd)
+{
+	remove_flag(cmd, "androidboot.enable_dm_verity=");
+	remove_flag(cmd, "androidboot.secboot=");
+	remove_flag(cmd, "androidboot.verifiedbootstate=");
+	remove_flag(cmd, "androidboot.veritymode=");
+}
+
 static int __init proc_cmdline_init(void)
 {
+	strcpy(new_command_line, saved_command_line);
+
+	/*
+	 * Remove various flags from command line seen by userspace in order to
+	 * pass SafetyNet CTS check.
+	 */
+	remove_safetynet_flags(new_command_line);
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }
-module_init(proc_cmdline_init);
+fs_initcall(proc_cmdline_init);


### PR DESCRIPTION
This is the original SafetyNet patch commited by Sultanxda for the unofficial Sultan LineageOS 14.1 builds, last updated ~23 days ago. I'm not _entirely_ sure it'll work for the surnia/osprey/harpia, but since the SafetyNet CTS check is failing on my Moto G 2015 since a couple of months ago (even with magiskhide), I thought it would be a good idea to give it a shot.

I'm not able to run a test build rn since my computer's hard drive is toast though, and both the source code and the toolchain are lost :/ so yeah.